### PR TITLE
Add Pi 1 Model B+ support

### DIFF
--- a/cpp/pi/rpi_bus.cpp
+++ b/cpp/pi/rpi_bus.cpp
@@ -616,7 +616,7 @@ RpiBus::PiType RpiBus::CheckForPi()
         return RpiBus::PiType::UNKNOWN;
     }
 
-    const int type = model.find("Zero") != string::npos ? 1 : model.substr(13, 1)[0] - '0';
+    const int type = model.find("Zero") != string::npos || model.find("Raspberry Pi Model B Plus") != string::npos ? 1 : model.substr(13, 1)[0] - '0';
     if (type <= 0 || type > 4) {
         warn("Unsupported Raspberry Pi model '{}', functionality is limited", model);
         return RpiBus::PiType::UNKNOWN;


### PR DESCRIPTION
When trying to use SCSI2Pi 5.1 with a PiSCSI v2.3B board and a [Raspberry Pi 1 Model B+](https://www.raspberrypi.com/products/raspberry-pi-1-model-b-plus/), I get the error:

```
Sep 06 23:19:41 raspberrypi s2p[322]: No RaSCSI/PiSCSI board support available, functionality is limited
```

The Pi 1 B+ is the same hardware as the Pi Zero, which works with SCSI2Pi, and the Pi 1 B+ also worked previously with the PiSCSI software, so I believed the Pi 1 B+ should also work with SCSI2Pi.

After some investigating I have tracked the issue down to the code that detects the Pi Version:

https://github.com/uweseimet/scsi2pi/blob/ee8236331990d98f8dfcb5827d61695d3d06f6ad/cpp/pi/rpi_bus.cpp#L619-L623

On my Pi 1 B+ the reported model is

```command
pi@raspberrypi:~ $ cat /proc/device-tree/model
Raspberry Pi Model B Plus Rev 1.2
```

and so when the code looks at character 13 instead of a number a "M" is returned falling outside of the valid range of 1 to 4.

This PR adds a special case to check for the Pi 1 B+, similar to the special check for the Pi Zero. I have compiled with this check in place and with this I can successfully run SCSI2Pi and emulate devices.

PS, Thank you for continuing to keep the PiSCSI/SCSI2Pi setup supported.